### PR TITLE
Fix turnOffDisplay function

### DIFF
--- a/drivers/ssd1306.mjs
+++ b/drivers/ssd1306.mjs
@@ -81,8 +81,8 @@ class SSD1306 {
 	};
 
 	// Turn OLED on
-	turnOnDisplay = async () => {
-		await this._transfer('cmd', this.DISPLAY_ON);
+	turnOffDisplay = async () => {
+		await this._transfer('cmd', this.DISPLAY_OFF);
 	};
 
 	// Send dim display command to oled


### PR DESCRIPTION
Update the duplicate function `turnOnDisplay` to the correct name `turnOffDisplay` and use the correct command buffer in `ssd1306.mjs`.